### PR TITLE
add guardduty automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,17 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
     posse --help for help
 ```
 
+### Deploy Guard Duty to AWS Organization
+```sh
+  posse aws \
+    guardduty \
+    set-administrator-account \
+    -administrator-account-role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
+    -root-role arn:aws:iam::222222222222:role/acme-gbl-root-admin \
+    --region us-west-2
+```
 
-
-
-## Examples
-
+examples: |-
 The utility can be called directly or as a Docker container.
 
 ### Build the Go program locally
@@ -123,6 +129,9 @@ Run `posse-cli` in a Docker container with local ENV vars propagated into the co
 docker run -i --rm \
         posse-cli
 ```
+
+
+
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -53,7 +53,17 @@ usage: |-
       posse --help for help
   ```
 
-examples: |-
+  ### Deploy Guard Duty to AWS Organization
+  ```sh
+    posse aws \
+      guardduty \
+      set-administrator-account \
+      -administrator-account-role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
+      -root-role arn:aws:iam::222222222222:role/acme-gbl-root-admin \
+      --region us-west-2
+  ```
+
+  examples: |-
   The utility can be called directly or as a Docker container.
 
   ### Build the Go program locally

--- a/aws/guardduty.go
+++ b/aws/guardduty.go
@@ -1,0 +1,152 @@
+/*
+Copyright © 2021 Cloud Posse, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	common "github.com/cloudposse/posse-cli/common/error"
+	"github.com/sirupsen/logrus"
+)
+
+func getGuardDutyClient(region string, role string) *guardduty.GuardDuty {
+	sess := GetSession()
+	creds := GetCreds(sess, role)
+	guardDutyClient := guardduty.New(sess, &aws.Config{Credentials: creds, Region: &region})
+
+	return guardDutyClient
+}
+
+func enableGuardDutyAdminAccount(client *guardduty.GuardDuty, accountID string) {
+	updateInput := guardduty.EnableOrganizationAdminAccountInput{AdminAccountId: &accountID}
+	client.EnableOrganizationAdminAccount(&updateInput)
+}
+
+// We need to enable GuardDuty in the AWS Organizations Management Account so that it can be added as a member
+// account in AWS GuardDuty's Administrator account. Accounts other than the Management Account don't need to be
+// excplicitly enabled, but the MA does.
+func enableGuardDutyInManagementAccount(client *guardduty.GuardDuty) {
+	_, err := client.CreateDetector(&guardduty.CreateDetectorInput{Enable: aws.Bool(true)})
+	if err != nil {
+		logrus.Error(err)
+	}
+}
+
+func isGuardDutyAdministratorAccountEnabled() bool {
+	return false
+}
+
+func containsGuardDutyAdminAccount(s []*guardduty.AdminAccount, e string) bool {
+	for _, a := range s {
+		if *a.AdminAccountId == e {
+			return true
+		}
+	}
+	return false
+}
+
+func guardDutyAdminAccountAlreadyEnabled(client *guardduty.GuardDuty, accountID string) bool {
+	listInput := guardduty.ListOrganizationAdminAccountsInput{}
+	orgConfig, err := client.ListOrganizationAdminAccounts(&listInput)
+	common.AssertErrorNil(err)
+	if containsGuardDutyAdminAccount(orgConfig.AdminAccounts, accountID) {
+		return true
+	}
+	return false
+}
+
+func logGuardDutyMemberAccounts(memberAccounts []AccountWithEmail) {
+	logrus.Info("  AWS GuardDuty Member accounts:")
+
+	for i := range memberAccounts {
+		logrus.Infof("    %s (%s)", memberAccounts[i].AccountID, memberAccounts[i].Email)
+	}
+}
+
+// addMemberAccount adds an account in the AWS Organization as a member of the GuardDuty Administrator Account
+func addGuardDutyMemberAccounts(client *guardduty.GuardDuty, detectorID string, memberAccounts []AccountWithEmail, administratorAcctID string) {
+	accountDetails := make([]*guardduty.AccountDetail, 0)
+	for i := range memberAccounts {
+		currentAccountID := memberAccounts[i].AccountID
+		currentEmailAddress := memberAccounts[i].Email
+		if currentAccountID != administratorAcctID {
+			accountDetails = append(accountDetails, &guardduty.AccountDetail{AccountId: &currentAccountID, Email: aws.String(currentEmailAddress)})
+		}
+	}
+	input := guardduty.CreateMembersInput{AccountDetails: accountDetails, DetectorId: aws.String(detectorID)}
+	result, err := client.CreateMembers(&input)
+	if err != nil {
+		logrus.Error(err)
+	}
+
+	if len(result.UnprocessedAccounts) > 0 {
+		logrus.Error(result)
+	}
+}
+
+func getDetectorIDForRegion(client *guardduty.GuardDuty) string {
+	detectors, err := client.ListDetectors(&guardduty.ListDetectorsInput{})
+	if err != nil {
+		logrus.Error(err)
+	}
+
+	if len(detectors.DetectorIds) == 0 {
+		logrus.Error("    No GuardDuty Detectors Found!")
+		return ""
+	}
+
+	return *detectors.DetectorIds[0]
+}
+
+// EnableGuardDutyAdministratorAccount enables the GuardDuty Administrator account within the AWS Organization
+func EnableGuardDutyAdministratorAccount(region string, administratorAccountRole string, rootRole string) error {
+	rootSession := GetSession()
+	rootAccountID := GetAccountID(rootSession, rootRole)
+
+	adminAcctSession := GetSession()
+	adminAccountID := GetAccountID(adminAcctSession, administratorAccountRole)
+
+	enabledRegions := GetEnabledRegions(rootRole)
+
+	logrus.Info("Enabling organization-wide AWS GuardDuty with the following config:")
+	logrus.Infof("  AWS Management Account %s", rootAccountID)
+	logrus.Infof("  AWS GuardDuty Administrator Account %s", adminAccountID)
+
+	memberAccounts := ListMemberAccountIDsWithEmails(rootRole)
+	logGuardDutyMemberAccounts(memberAccounts)
+
+	for r := range enabledRegions {
+		currentRegion := enabledRegions[r]
+		logrus.Infof("  Processing region %s", currentRegion)
+
+		rootAccountClient := getGuardDutyClient(currentRegion, rootRole)
+		adminAccountClient := getGuardDutyClient(currentRegion, administratorAccountRole)
+
+		if !guardDutyAdminAccountAlreadyEnabled(rootAccountClient, adminAccountID) {
+			enableGuardDutyAdminAccount(rootAccountClient, adminAccountID)
+			enableGuardDutyInManagementAccount(rootAccountClient)
+		} else {
+			logrus.Infof("    Account %s is already set as AWS GuardDuty Administrator Account, skipping configuration", adminAccountID)
+		}
+
+		detectorID := getDetectorIDForRegion(adminAccountClient)
+		addGuardDutyMemberAccounts(adminAccountClient, detectorID, memberAccounts, adminAccountID)
+	}
+	logrus.Infof("Organization-wide AWS GuardDuty complete")
+
+	return nil
+}

--- a/aws/guardduty.go
+++ b/aws/guardduty.go
@@ -98,6 +98,7 @@ func getDetectorIDForRegion(client *guardduty.GuardDuty) string {
 	detectors, err := client.ListDetectors(&guardduty.ListDetectorsInput{})
 	if err != nil {
 		logrus.Error(err)
+		return ""
 	}
 
 	if len(detectors.DetectorIds) == 0 {

--- a/aws/guardduty.go
+++ b/aws/guardduty.go
@@ -46,10 +46,6 @@ func enableGuardDutyInManagementAccount(client *guardduty.GuardDuty) {
 	}
 }
 
-func isGuardDutyAdministratorAccountEnabled() bool {
-	return false
-}
-
 func containsGuardDutyAdminAccount(s []*guardduty.AdminAccount, e string) bool {
 	for _, a := range s {
 		if *a.AdminAccountId == e {

--- a/aws/guardduty.go
+++ b/aws/guardduty.go
@@ -87,10 +87,10 @@ func addGuardDutyMemberAccounts(client *guardduty.GuardDuty, detectorID string, 
 	result, err := client.CreateMembers(&input)
 	if err != nil {
 		logrus.Error(err)
-	}
-
-	if len(result.UnprocessedAccounts) > 0 {
-		logrus.Error(result)
+	} else {
+		if len(result.UnprocessedAccounts) > 0 {
+			logrus.Error(result)
+		}
 	}
 }
 

--- a/aws/organizations.go
+++ b/aws/organizations.go
@@ -28,6 +28,12 @@ func getOrgClient(role string) *organizations.Organizations {
 	return organizations.New(sess, &aws.Config{Credentials: creds})
 }
 
+// AccountWithEmail contains AccountID and Email
+type AccountWithEmail struct {
+	AccountID string
+	Email     string
+}
+
 // ListMemberAccountIDs provides a list of AWS Accounts that are members of the AWS Organization
 func ListMemberAccountIDs(role string) []string {
 	client := getOrgClient(role)
@@ -40,4 +46,19 @@ func ListMemberAccountIDs(role string) []string {
 	}
 
 	return accountIDs
+}
+
+// ListMemberAccountIDsWithEmails provides a list of AWS Accounts that are members of the AWS Organization along with
+// their email addresses
+func ListMemberAccountIDsWithEmails(role string) []AccountWithEmail {
+	client := getOrgClient(role)
+	accounts, err := client.ListAccounts(&organizations.ListAccountsInput{})
+	common.AssertErrorNil(err)
+
+	accountsList := make([]AccountWithEmail, 0)
+	for i := range accounts.Accounts {
+		accountsList = append(accountsList, AccountWithEmail{AccountID: *accounts.Accounts[i].Id, Email: *accounts.Accounts[i].Email})
+	}
+
+	return accountsList
 }

--- a/aws/securityhub.go
+++ b/aws/securityhub.go
@@ -46,7 +46,8 @@ func enableSecurityHubInManagementAccount(client *securityhub.SecurityHub) {
 	}
 }
 
-func enableAutoEnable(client *securityhub.SecurityHub) {
+func enableSecurityHubAutoEnable(client *securityhub.SecurityHub) {
+	logrus.Info("    Setting Security Hub Auto-Enable for new AWS Organization Member Accounts")
 	updateInput := securityhub.UpdateOrganizationConfigurationInput{AutoEnable: aws.Bool(true)}
 	client.UpdateOrganizationConfiguration(&updateInput)
 }
@@ -128,7 +129,7 @@ func EnableSecurityHubAdministratorAccount(region string, administratorAccountRo
 
 		if !securityHubAdminAccountAlreadyEnabled(rootAccountClient, adminAccountID) {
 			enableSecurityHubAdminAccount(rootAccountClient, adminAccountID)
-			enableAutoEnable(adminAccountClient)
+			enableSecurityHubAutoEnable(adminAccountClient)
 			enableSecurityHubInManagementAccount(rootAccountClient)
 		} else {
 			logrus.Infof("    Account %s is already set as AWS Security Hub Administrator Account, skipping configuration", adminAccountID)

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -23,6 +23,13 @@ import (
 var region string
 var profile string
 
+// These flags are used in the GuardDuty and Security Hub sub-commands
+const adminAccountRoleFlag string = "administrator-account-role"
+const rootRoleFlag string = "root-role"
+
+var administratorAccountRole string
+var rootRole string
+
 var awsCmd = &cobra.Command{
 	Use:   "aws",
 	Short: "Commands related to automating AWS",

--- a/cmd/aws_guardduty.go
+++ b/cmd/aws_guardduty.go
@@ -1,0 +1,31 @@
+/*
+Copyright © 2021 Cloud Posse, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var guardDutyCmd = &cobra.Command{
+	Use:   "guardduty",
+	Short: "AWS GuardDuty automation tasks",
+	Long:  "AWS GuardDuty automation tasks",
+}
+
+func init() {
+	awsCmd.AddCommand(guardDutyCmd)
+}

--- a/cmd/aws_guardduty_setadministratoraccount.go
+++ b/cmd/aws_guardduty_setadministratoraccount.go
@@ -22,13 +22,17 @@ import (
 	"github.com/cloudposse/posse-cli/aws"
 )
 
+var autoEnableS3 bool
+
+const autoEnableS3Flag string = "auto-enable-s3-protection"
+
 var guardDutyAddMembersCmd = &cobra.Command{
 	Use:     "set-administrator-account",
 	Aliases: []string{"admin-account"},
 	Short:   "Set GuardDuty administrator account and member accounts",
 	Long:    "Designate the AWS Organization's AWS GuardDuty Admininstrator Account, then enable all the AWS Organization accounts as members",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return aws.EnableGuardDutyAdministratorAccount(region, administratorAccountRole, rootRole)
+		return aws.EnableGuardDutyAdministratorAccount(region, administratorAccountRole, rootRole, autoEnableS3)
 	},
 }
 
@@ -37,4 +41,5 @@ func init() {
 
 	guardDutyAddMembersCmd.Flags().StringVarP(&administratorAccountRole, adminAccountRoleFlag, "a", "", "The ARN of a role to assume with access to the organization's GuardDuty Administrator Account")
 	guardDutyAddMembersCmd.Flags().StringVarP(&rootRole, rootRoleFlag, "r", "", "The ARN of a role to assume with access to AWS Management Account")
+	guardDutyAddMembersCmd.Flags().BoolVarP(&autoEnableS3, autoEnableS3Flag, "", false, "Auto-enable S3 protection")
 }

--- a/cmd/aws_guardduty_setadministratoraccount.go
+++ b/cmd/aws_guardduty_setadministratoraccount.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2021 Cloud Posse, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cloudposse/posse-cli/aws"
+)
+
+var guardDutyAddMembersCmd = &cobra.Command{
+	Use:     "set-administrator-account",
+	Aliases: []string{"admin-account"},
+	Short:   "Set GuardDuty administrator account and member accounts",
+	Long:    "Designate the AWS Organization's AWS GuardDuty Admininstrator Account, then enable all the AWS Organization accounts as members",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return aws.EnableGuardDutyAdministratorAccount(region, administratorAccountRole, rootRole)
+	},
+}
+
+func init() {
+	guardDutyCmd.AddCommand(guardDutyAddMembersCmd)
+
+	guardDutyAddMembersCmd.Flags().StringVarP(&administratorAccountRole, adminAccountRoleFlag, "a", "", "The ARN of a role to assume with access to the organization's GuardDuty Administrator Account")
+	guardDutyAddMembersCmd.Flags().StringVarP(&rootRole, rootRoleFlag, "r", "", "The ARN of a role to assume with access to AWS Management Account")
+}

--- a/cmd/aws_securityhub.go
+++ b/cmd/aws_securityhub.go
@@ -23,8 +23,8 @@ import (
 var securityhubCmd = &cobra.Command{
 	Use:     "securityhub",
 	Aliases: []string{"hub", "sh"},
-	Short:   "AWS securityhub automation tasks",
-	Long:    "AWS securityhub automation tasks",
+	Short:   "AWS Security Hub automation tasks",
+	Long:    "AWS Security Hub automation tasks",
 }
 
 func init() {

--- a/cmd/aws_securityhub_setadministratoraccount.go
+++ b/cmd/aws_securityhub_setadministratoraccount.go
@@ -22,19 +22,13 @@ import (
 	"github.com/cloudposse/posse-cli/aws"
 )
 
-const adminAccountRoleFlag string = "administrator-account-role"
-const rootRoleFlag string = "root-role"
-
-var administratorAccountRole string
-var rootRole string
-
 var securityHubAddMembersCmd = &cobra.Command{
 	Use:     "set-administrator-account",
 	Aliases: []string{"admin-account"},
 	Short:   "Set Security Hub administrator account and member accounts",
 	Long:    "Designate the AWS Organization's AWS Security Hub Admininstrator Account, then enabled all the AWS Organization accounts as members",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return aws.EnableAdministratorAccount(region, administratorAccountRole, rootRole)
+		return aws.EnableSecurityHubAdministratorAccount(region, administratorAccountRole, rootRole)
 	},
 }
 

--- a/cmd/aws_securityhub_setadministratoraccount.go
+++ b/cmd/aws_securityhub_setadministratoraccount.go
@@ -31,8 +31,8 @@ var rootRole string
 var securityHubAddMembersCmd = &cobra.Command{
 	Use:     "set-administrator-account",
 	Aliases: []string{"admin-account"},
-	Short:   "Set SecurityHub administartor account and member accounts",
-	Long:    "Designate the AWS Organization's AWS SecurityHub Admininstrator Account, then enabled all the AWS Organization accounts as members",
+	Short:   "Set Security Hub administrator account and member accounts",
+	Long:    "Designate the AWS Organization's AWS Security Hub Admininstrator Account, then enabled all the AWS Organization accounts as members",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return aws.EnableAdministratorAccount(region, administratorAccountRole, rootRole)
 	},
@@ -41,6 +41,6 @@ var securityHubAddMembersCmd = &cobra.Command{
 func init() {
 	securityhubCmd.AddCommand(securityHubAddMembersCmd)
 
-	securityHubAddMembersCmd.Flags().StringVarP(&administratorAccountRole, adminAccountRoleFlag, "a", "", "The ARN of a role to assume with access to the organization's SecurityHub Administrator Account")
+	securityHubAddMembersCmd.Flags().StringVarP(&administratorAccountRole, adminAccountRoleFlag, "a", "", "The ARN of a role to assume with access to the organization's Security Hub Administrator Account")
 	securityHubAddMembersCmd.Flags().StringVarP(&rootRole, rootRoleFlag, "r", "", "The ARN of a role to assume with access to AWS Management Account")
 }


### PR DESCRIPTION
## what

Add command to enable AWS GuardDuty in the [GuardDuty Administrator account](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html) and associating all [AWS Organization](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts.html) accounts as GuardDuty Member Accounts.

## why

Support for AWS GuardDuty with AWS Organization integration is not available via Terraform.