### PR TITLE
add security hub disable-global-controls command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,34 @@ account can designate any account in the organization, including itself.
 posse aws \
   securityhub \
   set-administrator-account \
-  -administrator-account-role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
-  -root-role arn:aws:iam::222222222222:role/acme-gbl-root-admin \
+  --administrator-account-role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
+  --root-role arn:aws:iam::222222222222:role/acme-gbl-root-admin \
   --region us-west-2
+```
+
+### Disable Security Hub Controls
+DisableSecurityHubGlobalResourceControls disables Security Hub controls related to Global Resources in regions that
+aren't collecting Global Resources. It also disables CloudTrail related controls in accounts that aren't the central
+CloudTrail account.
+
+https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-cis-to-disable.html
+https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-to-disable.html
+
+```sh
+posse aws \
+  securityhub \
+  disable-global-controls \
+  --role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
+  --global-collector-region us-west-2
+```
+
+```sh
+posse aws \
+  securityhub \
+  disable-global-controls \
+  --role arn:aws:iam::111111111111:role/acme-gbl-audit-admin \
+  --global-collector-region us-west-2 \ 
+  --cloud-trail-account
 ```
 
 ### Deploy GuardDuty to AWS Organization

--- a/README.yaml
+++ b/README.yaml
@@ -103,9 +103,34 @@ examples: |-
   posse aws \
     securityhub \
     set-administrator-account \
-    -administrator-account-role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
-    -root-role arn:aws:iam::222222222222:role/acme-gbl-root-admin \
+    --administrator-account-role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
+    --root-role arn:aws:iam::222222222222:role/acme-gbl-root-admin \
     --region us-west-2
+  ```
+
+  ### Disable Security Hub Controls
+  DisableSecurityHubGlobalResourceControls disables Security Hub controls related to Global Resources in regions that
+  aren't collecting Global Resources. It also disables CloudTrail related controls in accounts that aren't the central
+  CloudTrail account.
+
+  https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-cis-to-disable.html
+  https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-to-disable.html
+
+  ```sh
+  posse aws \
+    securityhub \
+    disable-global-controls \
+    --role arn:aws:iam::111111111111:role/acme-gbl-security-admin \
+    --global-collector-region us-west-2
+  ```
+
+  ```sh
+  posse aws \
+    securityhub \
+    disable-global-controls \
+    --role arn:aws:iam::111111111111:role/acme-gbl-audit-admin \
+    --global-collector-region us-west-2 \ 
+    --cloud-trail-account
   ```
 
   ### Deploy GuardDuty to AWS Organization

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -22,8 +22,10 @@ import (
 
 var region string
 var profile string
+var role string
 
 // These flags are used in the GuardDuty and Security Hub sub-commands
+const roleFlag string = "role"
 const adminAccountRoleFlag string = "administrator-account-role"
 const rootRoleFlag string = "root-role"
 

--- a/cmd/aws_delete_default_vpcs.go
+++ b/cmd/aws_delete_default_vpcs.go
@@ -22,10 +22,8 @@ import (
 	"github.com/cloudposse/posse-cli/aws"
 )
 
-var role string
 var shouldDelete bool
 
-const roleFlag string = "role"
 const shouldDeleteFlag string = "delete"
 
 var deleteDefaultVPCsCmd = &cobra.Command{
@@ -43,6 +41,5 @@ var deleteDefaultVPCsCmd = &cobra.Command{
 func init() {
 	awsCmd.AddCommand(deleteDefaultVPCsCmd)
 
-	deleteDefaultVPCsCmd.Flags().StringVarP(&role, roleFlag, "r", "", "The ARN of a role to assume")
 	deleteDefaultVPCsCmd.Flags().BoolVarP(&shouldDelete, shouldDeleteFlag, "", false, "Flag to indicate if the delete should be run")
 }

--- a/cmd/aws_securityhub_disablecontrol.go
+++ b/cmd/aws_securityhub_disablecontrol.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2021 Cloud Posse, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/cloudposse/posse-cli/aws"
+	"github.com/spf13/cobra"
+)
+
+const cloudTrailAccountFlag string = "cloud-trail-account"
+const globalCollectionRegionFlag string = "global-collector-region"
+
+var isCloudTrailAccount bool
+var globalCollectionRegion string
+
+var securityHubDisableGlobalControlsCmd = &cobra.Command{
+	Use:   "disable-global-controls",
+	Short: "Disables Security Hub Global Resources controls in regions that aren't collecting Global Resources",
+	Long: `
+	Disables Security Hub Global Resources controls in regions that aren't collecting Global Resources and disables
+	CloudTrail related controls in accounts that are not the central CloudTrail account.
+
+	See the following AWS documentation for additional information:
+
+	https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-to-disable.html
+	https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-cis-to-disable.html
+	`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return aws.DisableSecurityHubGlobalResourceControls(globalCollectionRegion, role, isCloudTrailAccount)
+	},
+}
+
+func init() {
+	securityHubDisableGlobalControlsCmd.Flags().StringVarP(&globalCollectionRegion, globalCollectionRegionFlag, "g", region, "The AWS Region that contains the global resource collector")
+	securityHubDisableGlobalControlsCmd.Flags().StringVar(&role, roleFlag, "", "The ARN of a role to assume")
+	securityHubDisableGlobalControlsCmd.Flags().BoolVar(&isCloudTrailAccount, cloudTrailAccountFlag, false, "A flag to indicate if this account is the central CloudTrail account")
+
+	securityHubDisableGlobalControlsCmd.MarkFlagRequired(roleFlag)
+	securityHubDisableGlobalControlsCmd.MarkFlagRequired(globalCollectionRegionFlag)
+
+	securityhubCmd.AddCommand(securityHubDisableGlobalControlsCmd)
+}


### PR DESCRIPTION
## what

Add a new `posse aws securityhub disable-global-controls` command

## why

Disables Security Hub controls related to Global Resources in regions that aren't collecting Global Resources. It also disables CloudTrail related controls in accounts that aren't the central CloudTrail account.

See the following documentation for further information:

- https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-cis-to-disable.html
- https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-to-disable.html