### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,11 +16,11 @@ jobs:
         id: get_build_version
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            echo ::set-output name=VERSION::pr-${{ github.event.pull_request.number }}-merge
+            echo "VERSION=pr-${{ github.event.pull_request.number }}-merge" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=VERSION::${GITHUB_SHA}
+            echo "VERSION=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi
 
       - name: Prepare tags for Docker image


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/